### PR TITLE
Flood level back end

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -4,6 +4,7 @@ import mysql.connector
 import os
 import requests
 import time
+from datetime import datetime
 
 app = Flask(__name__)
 
@@ -86,28 +87,34 @@ def get_flood_level_data(flood_level, station_id, start_date, end_date):
     res = requests.get(req)
     resJson = res.json()
     flood = {}
-    floodCollection = []
-    floodLevels = []
-    floodCollectionData = {}
-    started = False
+    flood_levels = []
+    flood_collection = []
+    flood_collection_data_json = {}
+    flood_started = False
+
     for resJson in resJson['data']:
         if(resJson['v'] >= flood_level):
-            if(started == False):
+            if(flood_started == False):
                 flood['start_date'] = resJson['t']
-            floodLevels.append(resJson['v'])
-            started = True
-        elif(resJson['v'] < flood_level and started):
+            flood_levels.append(resJson['v'])
+            flood_started = True
+        elif(resJson['v'] < flood_level and flood_started):
             flood['end_date'] = resJson['t']
-            flood['flood_levels'] = floodLevels
-            floodCollection.append(flood)
-            
+            flood_collection.append(flood)
+            start_time = datetime.strptime(flood['start_date'], "%Y-%m-%d %H:%M")
+            end_time = datetime.strptime(flood['end_date'], "%Y-%m-%d %H:%M")
+            time_delta = str(abs(end_time - start_time))
+            print(time_delta)
+            flood['duration'] = json.dumps(time_delta)
+            flood['flood_levels'] = flood_levels
+
             # reset values
-            floodLevels = []
+            flood_levels = []
             flood = {}
-            started = False
+            flood_started = False
 
 
-    floodCollectionData['data'] = floodCollection
+    flood_collection_data_json['data'] = flood_collection
 
-    ret = json.dumps(floodCollectionData)
+    ret = json.dumps(flood_collection_data_json)
     return ret

--- a/api/app.py
+++ b/api/app.py
@@ -91,12 +91,16 @@ def get_flood_level_data(flood_level, station_id, start_date, end_date):
     flood_collection = []
     flood_collection_data_json = {}
     flood_started = False
+    num_of_floods = 0
+    metadata = {}
+    all_flood_levels = []
 
     for resJson in resJson['data']:
         if(resJson['v'] >= flood_level):
             if(flood_started == False):
                 flood['start_date'] = resJson['t']
             flood_levels.append(resJson['v'])
+            all_flood_levels.append(resJson['v'])
             flood_started = True
         elif(resJson['v'] < flood_level and flood_started):
             # get end date
@@ -107,6 +111,9 @@ def get_flood_level_data(flood_level, station_id, start_date, end_date):
             end_time = datetime.strptime(flood['end_date'], "%Y-%m-%d %H:%M")
             time_delta = str(abs(end_time - start_time))
             flood['duration'] = time_delta
+
+            # increment number of floods
+            num_of_floods = num_of_floods + 1
 
             # get average of flood levels
             sum = 0
@@ -127,7 +134,19 @@ def get_flood_level_data(flood_level, station_id, start_date, end_date):
             flood = {}
             flood_started = False
 
+    # metadata
+    metadata['num_of_floods'] = num_of_floods
+
+    sum = 0
+    for values in all_flood_levels:
+        sum = sum + float(values)
+
+    average = sum/len(all_flood_levels)
+    metadata['overall_average'] = "{:.3f}".format(average)
+
+    # store data in json
     flood_collection_data_json['data'] = flood_collection
+    flood_collection_data_json['metadata'] = metadata
 
     ret = json.dumps(flood_collection_data_json)
     return ret

--- a/api/app.py
+++ b/api/app.py
@@ -99,13 +99,25 @@ def get_flood_level_data(flood_level, station_id, start_date, end_date):
             flood_levels.append(resJson['v'])
             flood_started = True
         elif(resJson['v'] < flood_level and flood_started):
+            # get end date
             flood['end_date'] = resJson['t']
             flood_collection.append(flood)
+
+
+            # get duration
             start_time = datetime.strptime(flood['start_date'], "%Y-%m-%d %H:%M")
             end_time = datetime.strptime(flood['end_date'], "%Y-%m-%d %H:%M")
             time_delta = str(abs(end_time - start_time))
-            print(time_delta)
             flood['duration'] = json.dumps(time_delta)
+
+            # get average of flood levels
+            sum = 0
+            for values in flood_levels:
+                sum = sum + float(values)
+
+            average = sum/len(flood_levels)
+            flood['average'] = "{:.3f}".format(average)
+            
             flood['flood_levels'] = flood_levels
 
             # reset values

--- a/api/app.py
+++ b/api/app.py
@@ -101,14 +101,12 @@ def get_flood_level_data(flood_level, station_id, start_date, end_date):
         elif(resJson['v'] < flood_level and flood_started):
             # get end date
             flood['end_date'] = resJson['t']
-            flood_collection.append(flood)
-
 
             # get duration
             start_time = datetime.strptime(flood['start_date'], "%Y-%m-%d %H:%M")
             end_time = datetime.strptime(flood['end_date'], "%Y-%m-%d %H:%M")
             time_delta = str(abs(end_time - start_time))
-            flood['duration'] = json.dumps(time_delta)
+            flood['duration'] = time_delta
 
             # get average of flood levels
             sum = 0
@@ -118,13 +116,16 @@ def get_flood_level_data(flood_level, station_id, start_date, end_date):
             average = sum/len(flood_levels)
             flood['average'] = "{:.3f}".format(average)
             
+            # Store flood levels
             flood['flood_levels'] = flood_levels
+
+            # store flood data
+            flood_collection.append(flood)
 
             # reset values
             flood_levels = []
             flood = {}
             flood_started = False
-
 
     flood_collection_data_json['data'] = flood_collection
 


### PR DESCRIPTION
Json currently returns:
   - [x] start and end date of each flood
   - [x] duration of each flood
   - [x] average water level of each flood
   - [x] flood levels of each flood
   - [x] metadata that has overall average and number of floods 

Right now the end date of a flood is considered the date of the first water level that is under the flood level condition. Not sure if we want to change this to the end date being the last known water level that is greater than the flood threshold. 